### PR TITLE
Changed setup.py to use "py_modules" rather than "packages", so that …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ setuptools.setup(
     author_email="sbm199@gmail.com",
     description="Simple wrapper for the Met Office DataPoint API.",
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     url="https://github.com/sludgedesk/metoffer",
     license="LGPLv3+",
-    packages=setuptools.find_packages(),
+    py_modules=["metoffer"],
     package_data={"": ["*.txt", "*.rst"]},
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Changed setup.py to use "py_modules" rather than "packages", so that the distributions can be built correctly. This fixes [Issue #2](https://github.com/sludgedesk/metoffer/issues/2)

Also changed "long_description_content_type" to the correct value for "README.rst"